### PR TITLE
Update iSponsorBlockTV addon to version 2.6.0

### DIFF
--- a/isponsorblocktv/CHANGELOG.md
+++ b/isponsorblocktv/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## 2.6.0
+
+- Update upstream to latest (2.6.0)
+- Maintain Raspberry Pi 4 support via aarch64 architecture
+- Enhanced compatibility and bug fixes from upstream
+
 ## 2.3.0
 
 - Update upstream to latest

--- a/isponsorblocktv/config.yaml
+++ b/isponsorblocktv/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: iSponsorBlockTV add-on
-version: "2.3.0"
+version: "2.6.0"
 slug: isponsorblocktv
 description: SponsorBlock client for all YouTube TV clients.
 url: "https://github.com/bertybuttface/addons/tree/main/isponsorblocktv"


### PR DESCRIPTION
- Bump version from 2.3.0 to 2.6.0 to match upstream
- Maintain Raspberry Pi 4 support via aarch64 architecture
- Enhanced compatibility and bug fixes from upstream